### PR TITLE
feat(outlook): add helm chart

### DIFF
--- a/servers/outlook-mcp/chart/.helmignore
+++ b/servers/outlook-mcp/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/servers/outlook-mcp/chart/Chart.yaml
+++ b/servers/outlook-mcp/chart/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: mcp-server-outlook
+description: An experimental MCP server for Outlook leveraging the Microsoft Graph API.
+type: application
+version: 0.0.1 # TODO: Tag must be auto-injected via release process from package.json
+appVersion: 0.0.1 # FIXME: this does not work as intended sadly, this version does not trickle down into the dependency
+dependencies:
+  - alias: server
+    name: backend-service
+    repository: oci://ghcr.io/unique-ag/helm-charts
+    version: ~4.6.0

--- a/servers/outlook-mcp/chart/values.yaml
+++ b/servers/outlook-mcp/chart/values.yaml
@@ -1,0 +1,36 @@
+server:
+  extraRoutes:
+    # TODO: Only for MCP inspector, potentiallyremove before BETA or for production environments
+    mcp:
+      annotations:
+        konghq.com/plugins: unique-route-metrics
+        konghq.com/strip-path: "true"
+      enabled: true
+      matches:
+        - path:
+            type: PathPrefix
+            value: /mcp/server/outlook
+      parentRefs:
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: kong
+          namespace: system
+  image:
+    repository: ghcr.io/unique-ag/mcp/server/outlook-mcp # FIXME: Naming is not consistent, must be fixed before BETA (mcp is mentioned twice, mcp/servers/xxx-mcp)
+    tag: 0.0.1 # TODO: Tag must be auto-injected via release process from package.json
+  networkPolicy:
+    enabled: false # TODO: Policies must be defined as good practice, living documentation and as enterprise software and standard (ingress- and egress-policies)
+  ports:
+    application: 51345
+  probes:
+    enabled: false
+  prometheus:
+    enabled: false
+  resources:
+    limits:
+      cpu: 80m
+      memory: 128Mi
+    requests:
+      cpu: 40m
+      memory: 64Mi
+  # routes: can not use since that uses the JWT middleware, see extraRoutes


### PR DESCRIPTION
Adds native helm chart to deploy MCP Server Outlook.